### PR TITLE
Better logging - Dedicated class and local file output

### DIFF
--- a/DCT.pro
+++ b/DCT.pro
@@ -20,6 +20,7 @@ include("config/extradefines.pro")
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
+    logger.cpp \
     main.cpp \
     helpers.cpp \
     database.cpp \
@@ -30,7 +31,8 @@ HEADERS += \
     helpers.h \
     database.h \
     globalsettings.h \
-    lib/mousaviexecutesqlfile.h
+    lib/mousaviexecutesqlfile.h \
+    logger.h
 
 RESOURCES += qml.qrc
 

--- a/DCT.pro
+++ b/DCT.pro
@@ -43,7 +43,7 @@ include("lib/qt-google-analytics/qt-google-analytics.pri")
 #QML_IMPORT_PATH = C:\Qt\5.12.1\mingw73_64\qml
 
 # Additional import path used to resolve QML modules just for Qt Quick Designer
-QML_DESIGNER_IMPORT_PATH =
+#QML_DESIGNER_IMPORT_PATH =
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Macro | Incoming Transformation | Outgoing Transformation | What it does
 {timestamp} | Yes | Yes | Inserts the current time, as secs since epoch
 
 # Building
+First, note that this contains git *submodules*, so you either need to clone with `git clone --recursive`, or use `git submodule update --init` after cloning.
+
+Actual building:
  - So far I've only built for Windows, but there shouldn't be any Win specific dependencies in use. On my todo list is to build for Linux and OSX and see if there are any issues with the file read/writes
  - Compile tested with MSVC. Should work with MinGW too.
  - Steps should be as easy as:

--- a/database.h
+++ b/database.h
@@ -10,7 +10,7 @@ class Database
 {
 public:
     #ifdef QT_DEBUG
-    QString DB_PATH = "C:/Users/Joshua/Downloads/Temp/DCT/dct.db";
+    QString DB_PATH = "dct-debug.db";
     #else
     QString DB_PATH = "dct.db";
     #endif

--- a/globalsettings.cpp
+++ b/globalsettings.cpp
@@ -21,7 +21,7 @@ GlobalSettings *GlobalSettings::getInstance(){
 
 QString GlobalSettings::TABLE_NAME = "globalsettings";
 
-bool GlobalSettings::updateInBulk(QString cloudinaryCloudName, QString cloudinaryApiKey, QString cloudinaryApiSecret,bool optedOutTracking){
+bool GlobalSettings::updateInBulk(QString cloudinaryCloudName, QString cloudinaryApiKey, QString cloudinaryApiSecret){
     // @TODO refactor and call other validate function
     bool validated = true;
     QList<QString> emptyStringCheck = {cloudinaryCloudName,cloudinaryApiKey,cloudinaryApiSecret};
@@ -37,13 +37,10 @@ bool GlobalSettings::updateInBulk(QString cloudinaryCloudName, QString cloudinar
         m_cloudinaryCloudName = cloudinaryCloudName;
         m_cloudinaryApiKey = cloudinaryApiKey;
         m_cloudinaryApiSecret = cloudinaryApiSecret;
-        m_optedOutTracking = optedOutTracking;
-        this->saveToStorage();
     }
     else {
         m_cloudinaryProperlyConfigured = false;
     }
-    emit settingsChanged();
     return validated;
 }
 
@@ -52,8 +49,9 @@ void GlobalSettings::loadFromStorage(){
     m_cloudinaryApiKey = getSettingFromDb("cloudinaryApiKey").value.toString();
     m_cloudinaryApiSecret = getSettingFromDb("cloudinaryApiSecret").value.toString();
     m_optedOutTracking = getSettingFromDb("opted_out_tracking").value.toBool();
+    m_userDebugLogOn = getSettingFromDb("user_debuglog_on").value.toBool();
     m_cloudinaryProperlyConfigured = this->validateCloudinarySettings();
-    emit settingsChanged();
+    this->emitSettingsChanged();
 }
 
 void GlobalSettings::saveToStorage(){
@@ -61,6 +59,7 @@ void GlobalSettings::saveToStorage(){
     saveSettingToDb("cloudinaryApiKey",this->m_cloudinaryApiKey);
     saveSettingToDb("cloudinaryApiSecret",this->m_cloudinaryApiSecret);
     saveSettingToDb("opted_out_tracking",this->m_optedOutTracking);
+    saveSettingToDb("user_debuglog_on",this->m_userDebugLogOn);
 }
 
 settingDbResult GlobalSettings::getSettingFromDb(QString settingKey){

--- a/globalsettings.cpp
+++ b/globalsettings.cpp
@@ -4,6 +4,7 @@
 #include <QSqlRecord>
 #include <QSqlQueryModel>
 #include <QDebug>
+#include <logger.h>
 
 GlobalSettings::GlobalSettings(QObject *parent) : QObject(parent)
 {
@@ -60,6 +61,8 @@ void GlobalSettings::saveToStorage(){
     saveSettingToDb("cloudinaryApiSecret",this->m_cloudinaryApiSecret);
     saveSettingToDb("opted_out_tracking",this->m_optedOutTracking);
     saveSettingToDb("user_debuglog_on",this->m_userDebugLogOn);
+    Logger().refreshLogPrefs();
+    Logger().logStr("db updated");
 }
 
 settingDbResult GlobalSettings::getSettingFromDb(QString settingKey){

--- a/globalsettings.h
+++ b/globalsettings.h
@@ -41,6 +41,9 @@ public slots:
     QString getCloudinaryApiSecret(){
         return m_cloudinaryApiSecret;
     }
+    bool getUserDebugLogOn() {
+        return m_userDebugLogOn;
+    }
     void emitSettingsChanged(){
         emit settingsChanged();
     }

--- a/globalsettings.h
+++ b/globalsettings.h
@@ -19,6 +19,7 @@ class GlobalSettings : public QObject
     Q_PROPERTY(bool cloudinaryConfigured MEMBER m_cloudinaryProperlyConfigured NOTIFY settingsChanged)
     Q_PROPERTY(QString cloudinaryCloudName MEMBER m_cloudinaryCloudName NOTIFY settingsChanged)
     Q_PROPERTY(bool optedOutTracking MEMBER m_optedOutTracking NOTIFY settingsChanged)
+    Q_PROPERTY(bool userDebugLogOn MEMBER m_userDebugLogOn NOTIFY settingsChanged)
 public:
     explicit GlobalSettings(QObject *parent = nullptr);
     static GlobalSettings *getInstance();
@@ -28,7 +29,7 @@ signals:
     void settingsChanged();
     void internetConnectionChanged();
 public slots:
-    bool updateInBulk(QString cloudinaryCloudName, QString cloudinaryApiKey, QString cloudinaryApiSecret, bool optedOutTracking);
+    bool updateInBulk(QString cloudinaryCloudName, QString cloudinaryApiKey, QString cloudinaryApiSecret);
     void loadFromStorage();
     void saveToStorage();
     QString getCloudinaryCloudName(){
@@ -40,8 +41,8 @@ public slots:
     QString getCloudinaryApiSecret(){
         return m_cloudinaryApiSecret;
     }
-    bool getIsOptedOutTracking(){
-        return m_optedOutTracking;
+    void emitSettingsChanged(){
+        emit settingsChanged();
     }
 private:
     static GlobalSettings *m_instance;
@@ -52,6 +53,7 @@ private:
     bool m_hasInternet = false;
     settingDbResult getSettingFromDb(QString settingKey);
     bool saveSettingToDb(QString settingKey, QVariant settingVal);
+    bool m_userDebugLogOn = false;
     bool m_optedOutTracking = false;
 };
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -1,9 +1,9 @@
-#include "logger.h"
 #include "globalsettings.h"
+#include "helpers.h"
+#include "logger.h"
+#include <QDebug>
 #include <QFileInfo>
 #include <QTextStream>
-#include <QDebug>
-#include "helpers.h"
 
 Logger *Logger::m_instance = nullptr;
 
@@ -37,79 +37,30 @@ void Logger::refreshLogPrefs() {
     this->_logToFile = this->_userWantsLogging;
 }
 
-bool Logger::_openLogFile(QFile *filePtr) {
-    try {
-        filePtr = new QFile(_logFileDest);
-        //QFile file(_logFileDest);
-        //filePtr = &file;
-        filePtr->open(QIODevice::Append | QIODevice::Text);
-        QTextStream out(filePtr);
-        out << "\n\nOPENED!";
-        return true;
-    } catch (...) {
-        filePtr = nullptr;
-        return false;
-    }
-}
-
 QFile *Logger::_openLogFile() {
     QFile *filePtr = nullptr;
     try {
         filePtr = new QFile(_logFileDest);
         filePtr->open(QIODevice::Append | QIODevice::Text);
-        return filePtr;
     } catch (...) {
-        return filePtr;
+        qDebug() << "Could not open debug-log file";
     }
-}
-
-FILE *Logger::_openLogFileOs() {
-    FILE* filePtr = nullptr;
-    try {
-        QFile qfileObj(_logFileDest);
-        qfileObj.open(QIODevice::Append | QIODevice::Text);
-        int fileHndl = qfileObj.handle();
-        filePtr = _fdopen(fileHndl, "ab");
-        return filePtr;
-    } catch (...) {
-        return filePtr;
-    }
+    return filePtr;
 }
 
 void Logger::clear() {
     if (_logToFile) {
-        QFile *file = nullptr;
-        if(this->_openLogFile(file)) {
-            file->resize(0);
-            file->close();
-        }
+        QFile *file = this->_openLogFile();
+        file->resize(0);
+        file->close();
     }
 }
 
 void Logger::logStr(QString msg) {
     if (_logToFile) {
-
-        QFile* file;
-        /*
-        if(this->_openLogFile(&file)) {
-            //file.open(QIODevice::Append | QIODevice::Text);
-            QTextStream out(&file);
-            //file.write("FOOBAR");
-            out << msg;
-            file.close();
-        }
-        */
-
-        /*
-        FILE *file = this->_openLogFileOs();
+        QFile *file = this->_openLogFile();
         QTextStream out(file);
-        out << msg;
-        fclose(file);
-        */
-
-        file = this->_openLogFile();
-        QTextStream out(file);
-        out << msg;
+        out << "\n" << msg;
         file->close();
     }
     if (Helpers::getIsDebug()) {

--- a/logger.cpp
+++ b/logger.cpp
@@ -1,0 +1,118 @@
+#include "logger.h"
+#include "globalsettings.h"
+#include <QFileInfo>
+#include <QTextStream>
+#include <QDebug>
+#include "helpers.h"
+
+Logger *Logger::m_instance = nullptr;
+
+Logger *Logger::getInstance(){
+    if (m_instance == nullptr){
+        m_instance = new Logger();
+    }
+    return m_instance;
+}
+
+void Logger::_init() {
+    this->refreshLogPrefs();
+    if (_userWantsLogging && _logToFile) {
+        // Make sure log file exists
+        QFile file(_logFileDest);
+        if (!file.exists()) {
+            qDebug() << "log file does not exist -> creating now";
+            // Create
+            file.open(QIODevice::ReadWrite | QIODevice::Text);
+            file.write("");
+            file.close();
+        }
+        // Double check
+        _logToFile = QFileInfo::exists(_logFileDest);
+    }
+}
+
+void Logger::refreshLogPrefs() {
+    this->_userWantsLogging =  GlobalSettings::getInstance()->getUserDebugLogOn();
+    // For now, no separate setting for file vs other
+    this->_logToFile = this->_userWantsLogging;
+}
+
+bool Logger::_openLogFile(QFile *filePtr) {
+    try {
+        filePtr = new QFile(_logFileDest);
+        //QFile file(_logFileDest);
+        //filePtr = &file;
+        filePtr->open(QIODevice::Append | QIODevice::Text);
+        QTextStream out(filePtr);
+        out << "\n\nOPENED!";
+        return true;
+    } catch (...) {
+        filePtr = nullptr;
+        return false;
+    }
+}
+
+QFile *Logger::_openLogFile() {
+    QFile *filePtr = nullptr;
+    try {
+        filePtr = new QFile(_logFileDest);
+        filePtr->open(QIODevice::Append | QIODevice::Text);
+        return filePtr;
+    } catch (...) {
+        return filePtr;
+    }
+}
+
+FILE *Logger::_openLogFileOs() {
+    FILE* filePtr = nullptr;
+    try {
+        QFile qfileObj(_logFileDest);
+        qfileObj.open(QIODevice::Append | QIODevice::Text);
+        int fileHndl = qfileObj.handle();
+        filePtr = _fdopen(fileHndl, "ab");
+        return filePtr;
+    } catch (...) {
+        return filePtr;
+    }
+}
+
+void Logger::clear() {
+    if (_logToFile) {
+        QFile *file = nullptr;
+        if(this->_openLogFile(file)) {
+            file->resize(0);
+            file->close();
+        }
+    }
+}
+
+void Logger::logStr(QString msg) {
+    if (_logToFile) {
+
+        QFile* file;
+        /*
+        if(this->_openLogFile(&file)) {
+            //file.open(QIODevice::Append | QIODevice::Text);
+            QTextStream out(&file);
+            //file.write("FOOBAR");
+            out << msg;
+            file.close();
+        }
+        */
+
+        /*
+        FILE *file = this->_openLogFileOs();
+        QTextStream out(file);
+        out << msg;
+        fclose(file);
+        */
+
+        file = this->_openLogFile();
+        QTextStream out(file);
+        out << msg;
+        file->close();
+    }
+    if (Helpers::getIsDebug()) {
+        qDebug() << msg;
+    }
+}

--- a/logger.h
+++ b/logger.h
@@ -1,8 +1,8 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include <QString>
 #include <QFile>
+#include <QString>
 
 class Logger
 {
@@ -20,9 +20,7 @@ private:
     bool _logToFile = true;
     QString _logFileDest = "./debug-log.txt";
     bool _userWantsLogging = false;
-    bool _openLogFile(QFile *filePtr);
     QFile* _openLogFile();
-    FILE* _openLogFileOs();
 
 };
 

--- a/logger.h
+++ b/logger.h
@@ -1,0 +1,29 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <QString>
+#include <QFile>
+
+class Logger
+{
+public:
+    static Logger* getInstance();
+    Logger(){
+        this->_init();
+    }
+    void clear();
+    void logStr(QString msg);
+    void refreshLogPrefs();
+private:
+    static Logger *m_instance;
+    void _init();
+    bool _logToFile = true;
+    QString _logFileDest = "./debug-log.txt";
+    bool _userWantsLogging = false;
+    bool _openLogFile(QFile *filePtr);
+    QFile* _openLogFile();
+    FILE* _openLogFileOs();
+
+};
+
+#endif // LOGGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include "database.h"
 #include "globalsettings.h"
 #include "helpers.h"
+#include "logger.h"
 #include "models/stats.h"
 #include "models/transformationlist.h"
 #include "models/transformationconfig.h"
@@ -15,7 +16,6 @@
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
 #include <QQmlContext>
-#include "logger.h"
 
 int main(int argc, char *argv[])
 {

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
 #include <QQmlContext>
+#include "logger.h"
 
 int main(int argc, char *argv[])
 {
@@ -62,6 +63,9 @@ int main(int argc, char *argv[])
     // Log startup :)
     Stats::getInstance()->logStat("application","startup",false);
     Stats::getInstance()->fireGaEvent("application","startup","",NULL);
+    Logger *logger = Logger().getInstance();
+    logger->logStr("Program startup!");
+
 
     engine.load(QUrl(QStringLiteral("qrc:/qml/main.qml")));
     if (engine.rootObjects().isEmpty())

--- a/models/downloader.cpp
+++ b/models/downloader.cpp
@@ -1,4 +1,5 @@
 #include "downloader.h"
+#include "logger.h"
 
 Downloader *Downloader::m_instance = nullptr;
 
@@ -36,7 +37,9 @@ void Downloader::downloadImageFileToPathWithSlotString(QString remotePath, QStri
             }
             else {
                 // Uh-Oh!
-                qDebug() << "Download success, but IO error writing to disc at path : " << localPath;
+                QString errMsg = "Download success, but IO error writing to disc at path : " + localPath;
+                qDebug() << errMsg;
+                Logger().getInstance()->logStr(errMsg);
                 downloadWorked = false;
             }
             delete file;

--- a/models/uploader.cpp
+++ b/models/uploader.cpp
@@ -14,6 +14,7 @@
 
 Uploader::Uploader(QObject *parent) : QObject(parent)
 {
+    this->loggerInstance = Logger().getInstance();
 }
 
 Uploader *Uploader::m_instance = nullptr;
@@ -163,12 +164,16 @@ void Uploader::receiveNetworkReply(QNetworkReply *reply){
     }
 
     if (reply->error()){
+        QString errorMsg = reply->errorString();
         result.success = false;
         result.messageString = "Error in response from Cloudinary";
         qDebug() << "network reply error!";
-        qDebug() << reply->errorString();
+        qDebug() << errorMsg;
+        this->loggerInstance->logStr(errorMsg);
         if (reply->errorString().contains("TLS ",Qt::CaseInsensitive)){
-            qDebug() << "SSL build version = " << QSslSocket::sslLibraryVersionString() << " || SSL lib version = " << QSslSocket::sslLibraryVersionString();
+            QString sslErrMsg = "SSL build version = " + QSslSocket::sslLibraryVersionString() + " || SSL lib version = " + QSslSocket::sslLibraryVersionString();
+            qDebug() << sslErrMsg;
+            this->loggerInstance->logStr(sslErrMsg);
         }
     }
     else {

--- a/models/uploader.h
+++ b/models/uploader.h
@@ -5,6 +5,7 @@
 #include <QFile>
 #include <QtNetwork>
 #include "transformationconfig.h"
+#include "logger.h"
 
 struct UploadActionResult {
     bool success;
@@ -82,6 +83,7 @@ private:
     bool m_hasAttachedConfig = false;
     TransformationConfig m_attachedConfig;
     QString m_localFilePath;
+    Logger *loggerInstance;
 };
 
 Q_DECLARE_METATYPE(UploadActionResult);

--- a/qml/components/TopBar.qml
+++ b/qml/components/TopBar.qml
@@ -58,6 +58,7 @@ Item {
             anchors.topMargin: (parent.height - height) / 2
             Material.background: ThemeColors.darkAccent
             onClicked: {
+                settingsPopup.contentItem.resetForm();
                 settingsPopup.open();
             }
         }

--- a/qml/forms/SettingsEditor.qml
+++ b/qml/forms/SettingsEditor.qml
@@ -8,6 +8,7 @@ Item {
     anchors.fill: parent
     anchors.margins: 20
     property var cancelAction
+    property var settingsCopy: JSON.parse(JSON.stringify(GlobalSettings))
     Rectangle {
         anchors.fill: parent
         color: ThemeColors.darkAccent
@@ -100,7 +101,15 @@ Item {
                 CheckBox {
                     id: optedOutTrackingCheckbox
                     text: qsTr("Opt out of sharing of stats (note - this refers to DCT's stat sharing, not Cloudinary's)")
-                    checked: GlobalSettings.optedOutTracking
+                    checked: root.settingsCopy.optedOutTracking
+                }
+            }
+            Row {
+                width: parent.width
+                CheckBox {
+                    id: userDebugLogCheckbox
+                    text: qsTr("Turn on debug log")
+                    checked: root.settingsCopy.userDebugLogOn
                 }
             }
         }
@@ -140,12 +149,24 @@ Item {
     }
 
     property var submitForm: (function(){
-        var validated = GlobalSettings.updateInBulk(cloudinaryCloudNameInput.text,cloudinaryApiKeyInput.text,cloudinaryApiSecretInput.text,optedOutTrackingCheckbox.checked);
+        var validated = GlobalSettings.updateInBulk(cloudinaryCloudNameInput.text,cloudinaryApiKeyInput.text,cloudinaryApiSecretInput.text);
+        GlobalSettings.optedOutTracking = optedOutTrackingCheckbox.checked;
+        GlobalSettings.userDebugLogOn = userDebugLogCheckbox.checked;
+        GlobalSettings.emitSettingsChanged();
         if (validated){
+            GlobalSettings.saveToStorage();
             cancelAction();
         }
         else {
             formError.open();
         }
     })
+
+    property var resetForm: (function(){
+        // Necessary due to QML binding stuff
+        root.settingsCopy = JSON.parse(JSON.stringify(GlobalSettings));
+        cloudinaryCloudNameInput.text = GlobalSettings.getCloudinaryCloudName();
+        cloudinaryApiKeyInput.text = GlobalSettings.getCloudinaryApiKey();
+        cloudinaryApiSecretInput.text = GlobalSettings.getCloudinaryApiSecret();
+    });
 }


### PR DESCRIPTION
There is now a dedicated Logger class that is a wrapper around logging messages / errors.

It can be routed to qDebug and/or local text file, depending on user settings.

Added new UI toggle under settings, so users can turn the logging to file feature on or off (default is off)