### PR TITLE
Adding Cloudinary Public ID Macro Support ({uploadedId})

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Macros are case-insensitive; I'm using camelcase below just to make it easier to
 
 Macro | Incoming Transformation | Outgoing Transformation | What it does
 --- | --- | --- | ---
-{uploaded} | No | Yes | Inserts public ID as overlay - "l_PUBLICID"
+{uploaded} | No | Yes | Inserts public ID as overlay into chain - "l_PUBLICID"
+{uploadedId} | No | Yes | Inserts public ID, *as-is*
 {width} | Yes | Yes | Inserts width in pixels of local file being uploaded
 {height} | Yes | Yes | Inserts height in pixels of local file being uploaded
 {filename} | Yes | Yes | Inserts the filename *including* the extension

--- a/models/uploader.cpp
+++ b/models/uploader.cpp
@@ -211,7 +211,7 @@ void Uploader::receiveNetworkReply(QNetworkReply *reply){
 
             if (config.usesOutgoingTransformationRawString){
                 // Currently, it only makes sense to use this if the outgoing transformation string references the uploaded image.
-                if (config.outoingTransformationRawString.contains("{uploaded}",Qt::CaseInsensitive)){
+                if (config.outoingTransformationRawString.contains("{uploaded}",Qt::CaseInsensitive) || config.outoingTransformationRawString.contains("{uploadedId}",Qt::CaseInsensitive)) {
                     QString uploadImageMacroVal = "";
                     // We need to construct a NEW final image url
                     // Basically need to compute string to represent the BASE (original raw image) + any incoming trans (raw trans string, named preset, etc)
@@ -227,6 +227,7 @@ void Uploader::receiveNetworkReply(QNetworkReply *reply){
                         uploadImageMacroVal = "l_" + result.id;
                     }
                     QString finalOutgoingTransString = config.outoingTransformationRawString.replace("{uploaded}",uploadImageMacroVal,Qt::CaseSensitivity::CaseInsensitive);
+                    finalOutgoingTransString = finalOutgoingTransString.replace("{uploadedId}",result.id,Qt::CaseSensitivity::CaseInsensitive);
                     // Final macro replacements
                     finalOutgoingTransString = Uploader::macroReplacer(finalOutgoingTransString,this->m_localFilePath,QMap<QString,QString>());
                     finalOutgoingTransString = Cloudinary::autoEscapeTransString(finalOutgoingTransString);


### PR DESCRIPTION
This will fix issue #4 - Adding a macro to support inserting the uploaded image's public Cloudinary ID into the *outgoing* transformation string.